### PR TITLE
feat: implementa ApiKeyFilter de autenticação via X-API-KEY (#1)

### DIFF
--- a/src/main/java/com/VitorsosterF/exercicioPraticoAPIREST/security/ApiKeyFilter.java
+++ b/src/main/java/com/VitorsosterF/exercicioPraticoAPIREST/security/ApiKeyFilter.java
@@ -1,0 +1,36 @@
+package com.VitorsosterF.exercicioPraticoAPIREST.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class ApiKeyFilter extends OncePerRequestFilter {
+
+    @Value("${api.key}")
+    private String validApiKey;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String requestApiKey = request.getHeader("X-API-KEY");
+
+        if (requestApiKey == null || !requestApiKey.equals(validApiKey)) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType("application/json");
+            response.getWriter().write("{\"erro\": \"API Key inválida ou ausente\"}");
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,7 +4,7 @@ spring.application.name=exercicioPraticoAPIREST
 spring.h2.console.enabled=true
 spring.h2.console.path=/h2
 
-# Banco H2 em memória
+# Banco H2 em memÃ³ria
 spring.datasource.url=jdbc:h2:mem:meubanco
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
@@ -14,3 +14,6 @@ spring.datasource.password=
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.show-sql=true
+
+# API Key
+api.key=minha-chave-secreta-123


### PR DESCRIPTION
Cria o filtro ApiKeyFilter que intercepta todas as requisições e valida o header X-API-KEY. Retorna 401 caso a chave esteja ausente ou inválida.